### PR TITLE
handlers: use first-class deserializable types for query strings

### DIFF
--- a/src/handlers/artist_handler.rs
+++ b/src/handlers/artist_handler.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::{
     models::{artist::UserCreatedArtist, title_group::UserCreatedAffiliatedArtist, user::User},
     repositories::artist_repository::{
@@ -7,6 +5,7 @@ use crate::{
     },
 };
 use actix_web::{HttpResponse, web};
+use serde::Deserialize;
 use sqlx::PgPool;
 
 pub async fn add_artist(
@@ -37,12 +36,16 @@ pub async fn add_affiliated_artists(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct GetArtistPublications {
+    id: i32,
+}
+
 pub async fn get_artist_publications(
-    query: web::Query<HashMap<String, String>>,
+    query: web::Query<GetArtistPublications>,
     pool: web::Data<PgPool>,
 ) -> HttpResponse {
-    let artist_id = query.get("id").expect("id not found in query");
-    match find_artist_publications(&pool, &artist_id.parse::<i32>().unwrap()).await {
+    match find_artist_publications(&pool, &query.id).await {
         Ok(artist_publications) => {
             HttpResponse::Created().json(serde_json::json!(artist_publications))
         }

--- a/src/handlers/artist_handler.rs
+++ b/src/handlers/artist_handler.rs
@@ -37,7 +37,7 @@ pub async fn add_affiliated_artists(
 }
 
 #[derive(Debug, Deserialize)]
-pub struct GetArtistPublications {
+pub struct GetArtistPublicationsQuery {
     id: i32,
 }
 

--- a/src/handlers/auth_handler.rs
+++ b/src/handlers/auth_handler.rs
@@ -16,19 +16,25 @@ use argon2::{
 use chrono::Duration;
 use chrono::prelude::Utc;
 use jsonwebtoken::{EncodingKey, Header, encode};
+use serde::Deserialize;
 use sqlx::PgPool;
-use std::{collections::HashMap, env, net::IpAddr};
+use std::{env, net::IpAddr};
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterQuery {
+    invitation_key: Option<String>,
+}
 
 pub async fn register(
     new_user: web::Json<Register>,
     pool: web::Data<PgPool>,
     req: HttpRequest,
-    query: web::Query<HashMap<String, String>>,
+    query: web::Query<RegisterQuery>,
 ) -> HttpResponse {
     let invitation: Invitation;
     let open_signups = env::var("ARCADIA_OPEN_SIGNUPS").unwrap() == "true";
     if !open_signups {
-        let Some(invitation_key) = query.get("invitation_key") else {
+        let Some(invitation_key) = &query.invitation_key else {
             return HttpResponse::InternalServerError().json(serde_json::json!({
                 "error": "invitation key not found in query"
             }));

--- a/src/handlers/scrapers/open_library.rs
+++ b/src/handlers/scrapers/open_library.rs
@@ -1,12 +1,17 @@
 use actix_web::{HttpResponse, web};
 use chrono::NaiveDate;
+use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashMap;
 
 use crate::models::title_group::{ContentType, create_default_title_group};
 
-pub async fn get_open_library_data(query: web::Query<HashMap<String, String>>) -> HttpResponse {
-    let open_library_id = query.get("id").expect("id not found in query");
+#[derive(Debug, Deserialize)]
+pub struct GetOpenLibraryQuery {
+    id: String,
+}
+
+pub async fn get_open_library_data(query: web::Query<GetOpenLibraryQuery>) -> HttpResponse {
+    let open_library_id = &query.id;
     //TODO: check if there is an entry in the db with this open_library_id
     let mut title_group = create_default_title_group();
     title_group.external_links = vec![format!("https://openlibrary.org/works/{}", open_library_id)];

--- a/src/handlers/series_handler.rs
+++ b/src/handlers/series_handler.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
 use crate::{
     models::{series::UserCreatedSeries, user::User},
     repositories::series_repository::{create_series, find_series},
 };
 use actix_web::{HttpResponse, web};
+use serde::Deserialize;
 use sqlx::PgPool;
 
 pub async fn add_series(
@@ -20,12 +19,16 @@ pub async fn add_series(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct GetSeriesQuery {
+    id: i64,
+}
+
 pub async fn get_series(
     pool: web::Data<PgPool>,
-    query: web::Query<HashMap<String, String>>,
+    query: web::Query<GetSeriesQuery>,
 ) -> HttpResponse {
-    let series_id = query.get("id").expect("id not found in query");
-    match find_series(&pool, &series_id.parse::<i64>().unwrap()).await {
+    match find_series(&pool, &query.id).await {
         Ok(title_group) => HttpResponse::Ok().json(title_group),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/subscriptions_handler.rs
+++ b/src/handlers/subscriptions_handler.rs
@@ -1,27 +1,23 @@
-use std::collections::HashMap;
-
 use crate::{
     models::user::User,
     repositories::subscriptions_repository::{create_subscription, delete_subscription},
 };
 use actix_web::{HttpResponse, web};
+use serde::Deserialize;
 use sqlx::PgPool;
 
+#[derive(Debug, Deserialize)]
+pub struct AddSubscriptionQuery {
+    item_id: i64,
+    item: String,
+}
+
 pub async fn add_subscription(
-    query: web::Query<HashMap<String, String>>,
+    query: web::Query<AddSubscriptionQuery>,
     pool: web::Data<PgPool>,
     current_user: User,
 ) -> HttpResponse {
-    let item_id = query.get("item_id").expect("id not found in query");
-    let item = query.get("item").expect("item not found in query");
-    match create_subscription(
-        &pool,
-        &item_id.parse::<i64>().unwrap(),
-        &item,
-        &current_user,
-    )
-    .await
-    {
+    match create_subscription(&pool, &query.item_id, &query.item, &current_user).await {
         Ok(_) => HttpResponse::Created().json(serde_json::json!({"result": "success"})),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()
@@ -29,21 +25,14 @@ pub async fn add_subscription(
     }
 }
 
+pub type RemoveSubscriptionQuery = AddSubscriptionQuery;
+
 pub async fn remove_subscription(
-    query: web::Query<HashMap<String, String>>,
+    query: web::Query<RemoveSubscriptionQuery>,
     pool: web::Data<PgPool>,
     current_user: User,
 ) -> HttpResponse {
-    let item_id = query.get("item_id").expect("id not found in query");
-    let item = query.get("item").expect("item not found in query");
-    match delete_subscription(
-        &pool,
-        &item_id.parse::<i64>().unwrap(),
-        &item,
-        &current_user,
-    )
-    .await
-    {
+    match delete_subscription(&pool, &query.item_id, &query.item, &current_user).await {
         Ok(_) => HttpResponse::Created().json(serde_json::json!({"result": "success"})),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/title_group_handler.rs
+++ b/src/handlers/title_group_handler.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use actix_web::{HttpResponse, web};
+use serde::Deserialize;
 use sqlx::PgPool;
 
 use crate::{
@@ -23,13 +22,17 @@ pub async fn add_title_group(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct GetTitleGroupQuery {
+    id: i64,
+}
+
 pub async fn get_title_group(
     pool: web::Data<PgPool>,
-    query: web::Query<HashMap<String, String>>,
+    query: web::Query<GetTitleGroupQuery>,
     current_user: User,
 ) -> HttpResponse {
-    let title_group_id = query.get("id").expect("id not found in query");
-    match find_title_group(&pool, title_group_id.parse::<i64>().unwrap(), &current_user).await {
+    match find_title_group(&pool, query.id, &current_user).await {
         Ok(title_group) => HttpResponse::Ok().json(title_group),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()
@@ -37,12 +40,13 @@ pub async fn get_title_group(
     }
 }
 
+pub type GetLiteTitleGroupInfoQuery = GetTitleGroupQuery;
+
 pub async fn get_lite_title_group_info(
     pool: web::Data<PgPool>,
-    query: web::Query<HashMap<String, String>>,
+    query: web::Query<GetLiteTitleGroupInfoQuery>,
 ) -> HttpResponse {
-    let title_group_id = query.get("id").expect("id not found in query");
-    match find_lite_title_group_info(&pool, title_group_id.parse::<i64>().unwrap()).await {
+    match find_lite_title_group_info(&pool, query.id).await {
         Ok(title_group) => HttpResponse::Ok().json(title_group),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/user_handler.rs
+++ b/src/handlers/user_handler.rs
@@ -1,15 +1,15 @@
-use std::collections::HashMap;
-
 use crate::{models::user::User, repositories::user_repository::find_user_by_id};
 use actix_web::{HttpResponse, web};
+use serde::Deserialize;
 use sqlx::PgPool;
 
-pub async fn get_user(
-    pool: web::Data<PgPool>,
-    query: web::Query<HashMap<String, String>>,
-) -> HttpResponse {
-    let user_id = query.get("id").expect("id not found in query");
-    match find_user_by_id(&pool, &user_id.parse::<i64>().unwrap()).await {
+#[derive(Debug, Deserialize)]
+pub struct GetUserQuery {
+    id: i64,
+}
+
+pub async fn get_user(pool: web::Data<PgPool>, query: web::Query<GetUserQuery>) -> HttpResponse {
+    match find_user_by_id(&pool, &query.id).await {
         Ok(user) => HttpResponse::Created().json(serde_json::json!(user)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()


### PR DESCRIPTION
Let actix-web do the work of deserializing our query strings using the built-in extractors.  Simplify the handler code by using custom types for query.