### PR TITLE
repos: isolate from actix_web

### DIFF
--- a/src/repositories/artist_repository.rs
+++ b/src/repositories/artist_repository.rs
@@ -3,13 +3,12 @@ use crate::models::{
     title_group::{AffiliatedArtist, UserCreatedAffiliatedArtist},
     user::User,
 };
-use actix_web::web;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_artist(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     artist: &UserCreatedArtist,
     current_user: &User,
 ) -> Result<Artist, Box<dyn Error>> {
@@ -25,7 +24,7 @@ pub async fn create_artist(
         artist.pictures.as_deref(),
         current_user.id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match created_artist {
@@ -42,7 +41,7 @@ pub async fn create_artist(
 }
 
 pub async fn create_artists_affiliation(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     artists: &Vec<UserCreatedAffiliatedArtist>,
     current_user: &User,
 ) -> Result<Vec<AffiliatedArtist>, Box<dyn Error>> {
@@ -74,7 +73,7 @@ pub async fn create_artists_affiliation(
             .bind(current_user.id);
     }
 
-    match q.fetch_all(pool.as_ref()).await {
+    match q.fetch_all(pool).await {
         Ok(affiliated_artists) => Ok(affiliated_artists),
         Err(e) => {
             println!("{:#?}", e);
@@ -92,7 +91,7 @@ pub async fn create_artists_affiliation(
 }
 
 pub async fn find_artist_publications(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     artist_id: &i32,
 ) -> Result<Value, Box<dyn Error>> {
     // TODO: only select the required info about the torrents (mediainfo etc is not necessary)
@@ -138,7 +137,7 @@ FROM artist_title_groups tg
 LEFT JOIN torrent_request_data trd ON trd.title_group_id = tg.id;"#,
         artist_id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match artist_publications {

--- a/src/repositories/auth_repository.rs
+++ b/src/repositories/auth_repository.rs
@@ -13,7 +13,7 @@ use sqlx::{PgPool, types::ipnetwork::IpNetwork};
 use std::{env, error::Error};
 
 pub async fn create_user(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     user: &Register,
     from_ip: IpNetwork,
     password_hash: &str,
@@ -32,7 +32,7 @@ pub async fn create_user(
         password_hash,
         from_ip
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match registered_user {
@@ -47,7 +47,7 @@ pub async fn create_user(
                     registered_user.id,
                     invitation.id
                 )
-                .execute(pool.get_ref())
+                .execute(pool)
                 .await;
             }
 
@@ -63,10 +63,7 @@ pub async fn create_user(
     }
 }
 
-pub async fn find_user_with_password(
-    pool: &web::Data<PgPool>,
-    user: &Login,
-) -> Result<User, Box<dyn Error>> {
+pub async fn find_user_with_password(pool: &PgPool, user: &Login) -> Result<User, Box<dyn Error>> {
     let result = sqlx::query_as!(
         User,
         r#"
@@ -75,7 +72,7 @@ pub async fn find_user_with_password(
         "#,
         user.username
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match result {

--- a/src/repositories/edition_group_repository.rs
+++ b/src/repositories/edition_group_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     edition_group::{EditionGroup, UserCreatedEditionGroup},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_edition_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     edition_group_form: &UserCreatedEditionGroup,
     current_user: &User,
 ) -> Result<EditionGroup, Box<dyn Error>> {
@@ -28,7 +27,7 @@ pub async fn create_edition_group(
         .bind(&edition_group_form.external_links)
         .bind(&edition_group_form.source)
         .bind(&edition_group_form.additional_information)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_edition_group {

--- a/src/repositories/invitation_repository.rs
+++ b/src/repositories/invitation_repository.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 
-use actix_web::web;
 use rand::{
     distr::{Alphanumeric, SampleString},
     rng,
@@ -13,7 +12,7 @@ use crate::models::{
 };
 
 pub async fn create_invitation(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     invitation: &SentInvitation,
     current_user: &User,
 ) -> Result<Invitation, Box<dyn Error>> {
@@ -40,7 +39,7 @@ pub async fn create_invitation(
         current_user.id,
         invitation.receiver_email
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match sent_invitation {
@@ -57,7 +56,7 @@ pub async fn create_invitation(
 }
 
 pub async fn does_invitation_exist(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     invitation_key: &str,
 ) -> Result<Invitation, Box<dyn Error>> {
     // TODO: test and handle expiration
@@ -68,7 +67,7 @@ pub async fn does_invitation_exist(
         "#,
         invitation_key
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match invitation {
@@ -85,7 +84,7 @@ pub async fn does_invitation_exist(
 }
 
 pub async fn set_invitations_available(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     amount: i16,
     current_user: &User,
 ) -> Result<(), Box<dyn Error>> {
@@ -97,7 +96,7 @@ pub async fn set_invitations_available(
         amount,
         current_user.id
     )
-    .execute(pool.get_ref())
+    .execute(pool)
     .await;
 
     match result {

--- a/src/repositories/master_group_repository.rs
+++ b/src/repositories/master_group_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     master_group::{MasterGroup, UserCreatedMasterGroup},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_master_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     master_group_form: &UserCreatedMasterGroup,
     current_user: &User,
 ) -> Result<MasterGroup, Box<dyn Error>> {
@@ -29,7 +28,7 @@ pub async fn create_master_group(
         // .bind(&master_group_form.fan_arts)
         // .bind(&master_group_form.category)
         // .bind(&master_group_form.tags)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_master_group {

--- a/src/repositories/notification_repository.rs
+++ b/src/repositories/notification_repository.rs
@@ -1,9 +1,8 @@
-use actix_web::web;
 use sqlx::{PgPool, postgres::PgQueryResult};
 use std::error::Error;
 
 pub async fn notify_users(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     event: &str,
     item_id: &i64,
     title: &str,
@@ -32,7 +31,7 @@ pub async fn notify_users(
                 title,
                 message
             )
-            .execute(pool.get_ref())
+            .execute(pool)
             .await;
         }
         _ => {

--- a/src/repositories/series_repository.rs
+++ b/src/repositories/series_repository.rs
@@ -2,13 +2,12 @@ use crate::models::{
     series::{Series, UserCreatedSeries},
     user::User,
 };
-use actix_web::web;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_series(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     series: &UserCreatedSeries,
     current_user: &User,
 ) -> Result<Series, Box<dyn Error>> {
@@ -26,7 +25,7 @@ pub async fn create_series(
         &series.banners,
         &series.tags
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match created_series {
@@ -42,10 +41,7 @@ pub async fn create_series(
     }
 }
 
-pub async fn find_series(
-    pool: &web::Data<PgPool>,
-    series_id: &i64,
-) -> Result<Value, Box<dyn Error>> {
+pub async fn find_series(pool: &PgPool, series_id: &i64) -> Result<Value, Box<dyn Error>> {
     let found_series = sqlx::query!(
         r#"
             WITH title_group_data AS (
@@ -82,7 +78,7 @@ pub async fn find_series(
         "#,
         series_id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match found_series {

--- a/src/repositories/subscriptions_repository.rs
+++ b/src/repositories/subscriptions_repository.rs
@@ -1,10 +1,9 @@
 use crate::models::user::User;
-use actix_web::web;
 use sqlx::{PgPool, postgres::PgQueryResult};
 use std::error::Error;
 
 pub async fn create_subscription(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     item_id: &i64,
     item: &str,
     current_user: &User,
@@ -20,7 +19,7 @@ pub async fn create_subscription(
                 item_id,
                 current_user.id
             )
-            .execute(pool.get_ref())
+            .execute(pool)
             .await;
         }
         _ => {
@@ -42,7 +41,7 @@ pub async fn create_subscription(
 }
 
 pub async fn delete_subscription(
-    pool: &web::Data<sqlx::PgPool>,
+    pool: &PgPool,
     item_id: &i64,
     item: &str,
     current_user: &User,
@@ -58,7 +57,7 @@ pub async fn delete_subscription(
                 item_id,
                 current_user.id
             )
-            .execute(pool.get_ref())
+            .execute(pool)
             .await;
         }
         _ => {

--- a/src/repositories/title_group_comment_repository.rs
+++ b/src/repositories/title_group_comment_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     title_group_comment::{TitleGroupComment, UserCreatedTitleGroupComment},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_title_group_comment(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_comment: &UserCreatedTitleGroupComment,
     current_user: &User,
 ) -> Result<TitleGroupComment, Box<dyn Error>> {
@@ -24,7 +23,7 @@ pub async fn create_title_group_comment(
             .bind(&current_user.id)
             .bind(&title_group_comment.refers_to_torrent_id)
             .bind(&title_group_comment.answers_to_comment_id)
-            .fetch_one(pool.get_ref())
+            .fetch_one(pool)
             .await;
 
     match created_title_group_comment {

--- a/src/repositories/title_group_repository.rs
+++ b/src/repositories/title_group_repository.rs
@@ -2,13 +2,12 @@ use crate::models::{
     title_group::{TitleGroup, UserCreatedTitleGroup},
     user::User,
 };
-use actix_web::web;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_title_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_form: &UserCreatedTitleGroup,
     current_user: &User,
 ) -> Result<TitleGroup, Box<dyn Error>> {
@@ -35,7 +34,7 @@ pub async fn create_title_group(
         .bind(&title_group_form.tags)
         .bind(&title_group_form.tagline)
         // .bind(&title_group_form.public_ratings)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_title_group {
@@ -52,7 +51,7 @@ pub async fn create_title_group(
 }
 
 pub async fn find_title_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_id: i64,
     current_user: &User,
 ) -> Result<Value, Box<dyn Error>> {
@@ -142,7 +141,7 @@ LEFT JOIN series_data sd ON sd.title_group_id = tg.id
 LEFT JOIN torrent_request_data trd ON trd.title_group_id = tg.id
 LEFT JOIN subscription_data sud ON sud.id = tg.id
 WHERE tg.id = $2;"#, current_user.id, title_group_id)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match title_group {
@@ -158,7 +157,7 @@ WHERE tg.id = $2;"#, current_user.id, title_group_id)
     }
 }
 pub async fn find_lite_title_group_info(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_id: i64,
 ) -> Result<Value, Box<dyn Error>> {
     let title_group = sqlx::query!(
@@ -184,7 +183,7 @@ WHERE tg.id = $1
 GROUP BY tg.id;"#,
         title_group_id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match title_group {

--- a/src/repositories/torrent_repository.rs
+++ b/src/repositories/torrent_repository.rs
@@ -2,7 +2,6 @@ use crate::models::{
     torrent::{Features, Torrent, UploadedTorrent},
     user::User,
 };
-use actix_web::web;
 use bip_metainfo::Metainfo;
 use serde_json::json;
 use sqlx::PgPool;
@@ -18,7 +17,7 @@ struct LiteTitleGroupInfo {
 }
 
 pub async fn create_torrent(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     torrent_form: &UploadedTorrent,
     current_user: &User,
 ) -> Result<Torrent, Box<dyn Error>> {
@@ -126,7 +125,7 @@ pub async fn create_torrent(
         .bind(torrent_form.video_resolution.as_deref())
         .bind(&*torrent_form.container)
         .bind(torrent_form.language.as_deref())
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     // TODO: edit the torrent file with proper flags, remove announce url and store it to the disk
@@ -141,7 +140,7 @@ pub async fn create_torrent(
         WHERE edition_groups.id = $1",
                 &torrent_form.edition_group_id.0
             )
-            .fetch_one(&***pool)
+            .fetch_one(pool)
             .await?;
             let _ = notify_users(
                 pool,

--- a/src/repositories/torrent_request_repository.rs
+++ b/src/repositories/torrent_request_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     torrent_request::{TorrentRequest, UserCreatedTorrentRequest},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_torrent_request(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     torrent_request: &UserCreatedTorrentRequest,
     current_user: &User,
 ) -> Result<TorrentRequest, Box<dyn Error>> {
@@ -38,7 +37,7 @@ pub async fn create_torrent_request(
         .bind(&torrent_request.video_resolution)
         .bind(&torrent_request.bounty_upload)
         .bind(&torrent_request.bounty_bonus_points)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_torrent_request {

--- a/src/repositories/torrent_request_vote_repository.rs
+++ b/src/repositories/torrent_request_vote_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     torrent_request_vote::{TorrentRequestVote, UserCreatedTorrentRequestVote},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_torrent_request_vote(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     torrent_request_vote: &UserCreatedTorrentRequestVote,
     current_user: &User,
 ) -> Result<TorrentRequestVote, Box<dyn Error>> {
@@ -51,7 +50,7 @@ FROM inserted_vote;"#;
             .bind(&current_user.id)
             .bind(&torrent_request_vote.bounty_upload)
             .bind(&torrent_request_vote.bounty_bonus_points)
-            .fetch_one(pool.get_ref())
+            .fetch_one(pool)
             .await;
 
     match created_torrent_request_vote {

--- a/src/repositories/user_repository.rs
+++ b/src/repositories/user_repository.rs
@@ -1,12 +1,8 @@
 use crate::models::user::{PublicUser, User};
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
-pub async fn find_user_by_username(
-    pool: &web::Data<PgPool>,
-    username: &str,
-) -> Result<User, Box<dyn Error>> {
+pub async fn find_user_by_username(pool: &PgPool, username: &str) -> Result<User, Box<dyn Error>> {
     let result = sqlx::query_as!(
         User,
         r#"
@@ -15,7 +11,7 @@ pub async fn find_user_by_username(
         "#,
         username
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match result {
@@ -29,10 +25,7 @@ pub async fn find_user_by_username(
         }
     }
 }
-pub async fn find_user_by_id(
-    pool: &web::Data<PgPool>,
-    id: &i64,
-) -> Result<PublicUser, Box<dyn Error>> {
+pub async fn find_user_by_id(pool: &PgPool, id: &i64) -> Result<PublicUser, Box<dyn Error>> {
     // TODO: use id BIGINT PRIMARY KEY GENERATED ALWAYS AS DEFAULT
     let result = sqlx::query_as!(
         PublicUser,
@@ -71,7 +64,7 @@ pub async fn find_user_by_id(
         "#,
         *id as i32
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match result {


### PR DESCRIPTION
Simplify the repositories such that they no longer know anything about being used from the context of actix_web.  This should be a maintained architectural goal.