### PR TITLE
arcadia: create a container for top-level app state

### DIFF
--- a/src/handlers/artist_handler.rs
+++ b/src/handlers/artist_handler.rs
@@ -1,4 +1,5 @@
 use crate::{
+    Arcadia,
     models::{artist::UserCreatedArtist, title_group::UserCreatedAffiliatedArtist, user::User},
     repositories::artist_repository::{
         create_artist, create_artists_affiliation, find_artist_publications,
@@ -6,14 +7,13 @@ use crate::{
 };
 use actix_web::{HttpResponse, web};
 use serde::Deserialize;
-use sqlx::PgPool;
 
 pub async fn add_artist(
     artist: web::Json<UserCreatedArtist>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_artist(&pool, &artist, &current_user).await {
+    match create_artist(&arc.pool, &artist, &current_user).await {
         Ok(created_artist) => HttpResponse::Created().json(serde_json::json!(created_artist)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()
@@ -23,10 +23,10 @@ pub async fn add_artist(
 
 pub async fn add_affiliated_artists(
     artists: web::Json<Vec<UserCreatedAffiliatedArtist>>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_artists_affiliation(&pool, &artists, &current_user).await {
+    match create_artists_affiliation(&arc.pool, &artists, &current_user).await {
         Ok(created_affiliations) => {
             HttpResponse::Created().json(serde_json::json!(created_affiliations))
         }
@@ -43,9 +43,9 @@ pub struct GetArtistPublicationsQuery {
 
 pub async fn get_artist_publications(
     query: web::Query<GetArtistPublicationsQuery>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
 ) -> HttpResponse {
-    match find_artist_publications(&pool, &query.id).await {
+    match find_artist_publications(&arc.pool, &query.id).await {
         Ok(artist_publications) => {
             HttpResponse::Created().json(serde_json::json!(artist_publications))
         }

--- a/src/handlers/edition_group_handler.rs
+++ b/src/handlers/edition_group_handler.rs
@@ -1,16 +1,16 @@
 use crate::{
+    Arcadia,
     models::{edition_group::UserCreatedEditionGroup, user::User},
     repositories::edition_group_repository::create_edition_group,
 };
 use actix_web::{HttpResponse, web};
-use sqlx::PgPool;
 
 pub async fn add_edition_group(
     form: web::Json<UserCreatedEditionGroup>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_edition_group(&pool, &form, &current_user).await {
+    match create_edition_group(&arc.pool, &form, &current_user).await {
         Ok(edition_group) => HttpResponse::Created().json(serde_json::json!(edition_group)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/invitation_handler.rs
+++ b/src/handlers/invitation_handler.rs
@@ -1,13 +1,13 @@
 use crate::{
+    Arcadia,
     models::{invitation::SentInvitation, user::User},
     repositories::invitation_repository::create_invitation,
 };
 use actix_web::{HttpResponse, web};
-use sqlx::PgPool;
 
 pub async fn send_invitation(
     invitation: web::Json<SentInvitation>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
     if current_user.invitations == 0 {
@@ -18,7 +18,7 @@ pub async fn send_invitation(
 
     // TODO: send email to the user who receives the invite
 
-    match create_invitation(&pool, &invitation, &current_user).await {
+    match create_invitation(&arc.pool, &invitation, &current_user).await {
         Ok(user) => HttpResponse::Created().json(serde_json::json!(user)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/master_group_handler.rs
+++ b/src/handlers/master_group_handler.rs
@@ -1,16 +1,16 @@
 use crate::{
+    Arcadia,
     models::{master_group::UserCreatedMasterGroup, user::User},
     repositories::master_group_repository::create_master_group,
 };
 use actix_web::{HttpResponse, web};
-use sqlx::PgPool;
 
 pub async fn add_master_group(
     form: web::Json<UserCreatedMasterGroup>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_master_group(&pool, &form, &current_user).await {
+    match create_master_group(&arc.pool, &form, &current_user).await {
         Ok(master_group) => HttpResponse::Created().json(serde_json::json!(master_group)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/series_handler.rs
+++ b/src/handlers/series_handler.rs
@@ -1,17 +1,17 @@
 use crate::{
+    Arcadia,
     models::{series::UserCreatedSeries, user::User},
     repositories::series_repository::{create_series, find_series},
 };
 use actix_web::{HttpResponse, web};
 use serde::Deserialize;
-use sqlx::PgPool;
 
 pub async fn add_series(
     serie: web::Json<UserCreatedSeries>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_series(&pool, &serie, &current_user).await {
+    match create_series(&arc.pool, &serie, &current_user).await {
         Ok(created_serie) => HttpResponse::Created().json(serde_json::json!(created_serie)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()
@@ -25,10 +25,10 @@ pub struct GetSeriesQuery {
 }
 
 pub async fn get_series(
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     query: web::Query<GetSeriesQuery>,
 ) -> HttpResponse {
-    match find_series(&pool, &query.id).await {
+    match find_series(&arc.pool, &query.id).await {
         Ok(title_group) => HttpResponse::Ok().json(title_group),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/subscriptions_handler.rs
+++ b/src/handlers/subscriptions_handler.rs
@@ -1,10 +1,10 @@
 use crate::{
+    Arcadia,
     models::user::User,
     repositories::subscriptions_repository::{create_subscription, delete_subscription},
 };
 use actix_web::{HttpResponse, web};
 use serde::Deserialize;
-use sqlx::PgPool;
 
 #[derive(Debug, Deserialize)]
 pub struct AddSubscriptionQuery {
@@ -14,10 +14,10 @@ pub struct AddSubscriptionQuery {
 
 pub async fn add_subscription(
     query: web::Query<AddSubscriptionQuery>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_subscription(&pool, &query.item_id, &query.item, &current_user).await {
+    match create_subscription(&arc.pool, &query.item_id, &query.item, &current_user).await {
         Ok(_) => HttpResponse::Created().json(serde_json::json!({"result": "success"})),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()
@@ -29,10 +29,10 @@ pub type RemoveSubscriptionQuery = AddSubscriptionQuery;
 
 pub async fn remove_subscription(
     query: web::Query<RemoveSubscriptionQuery>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match delete_subscription(&pool, &query.item_id, &query.item, &current_user).await {
+    match delete_subscription(&arc.pool, &query.item_id, &query.item, &current_user).await {
         Ok(_) => HttpResponse::Created().json(serde_json::json!({"result": "success"})),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/title_group_comment_handler.rs
+++ b/src/handlers/title_group_comment_handler.rs
@@ -1,16 +1,16 @@
 use crate::{
+    Arcadia,
     models::{title_group_comment::UserCreatedTitleGroupComment, user::User},
     repositories::title_group_comment_repository::create_title_group_comment,
 };
 use actix_web::{HttpResponse, web};
-use sqlx::PgPool;
 
 pub async fn add_title_group_comment(
     comment: web::Json<UserCreatedTitleGroupComment>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_title_group_comment(&pool, &comment, &current_user).await {
+    match create_title_group_comment(&arc.pool, &comment, &current_user).await {
         Ok(created_comment) => HttpResponse::Created().json(serde_json::json!(created_comment)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/title_group_handler.rs
+++ b/src/handlers/title_group_handler.rs
@@ -1,8 +1,8 @@
 use actix_web::{HttpResponse, web};
 use serde::Deserialize;
-use sqlx::PgPool;
 
 use crate::{
+    Arcadia,
     models::{title_group::UserCreatedTitleGroup, user::User},
     repositories::title_group_repository::{
         create_title_group, find_lite_title_group_info, find_title_group,
@@ -11,10 +11,10 @@ use crate::{
 
 pub async fn add_title_group(
     form: web::Json<UserCreatedTitleGroup>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_title_group(&pool, &form, &current_user).await {
+    match create_title_group(&arc.pool, &form, &current_user).await {
         Ok(title_group) => HttpResponse::Created().json(serde_json::json!(title_group)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()
@@ -28,11 +28,11 @@ pub struct GetTitleGroupQuery {
 }
 
 pub async fn get_title_group(
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     query: web::Query<GetTitleGroupQuery>,
     current_user: User,
 ) -> HttpResponse {
-    match find_title_group(&pool, query.id, &current_user).await {
+    match find_title_group(&arc.pool, query.id, &current_user).await {
         Ok(title_group) => HttpResponse::Ok().json(title_group),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()
@@ -43,10 +43,10 @@ pub async fn get_title_group(
 pub type GetLiteTitleGroupInfoQuery = GetTitleGroupQuery;
 
 pub async fn get_lite_title_group_info(
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     query: web::Query<GetLiteTitleGroupInfoQuery>,
 ) -> HttpResponse {
-    match find_lite_title_group_info(&pool, query.id).await {
+    match find_lite_title_group_info(&arc.pool, query.id).await {
         Ok(title_group) => HttpResponse::Ok().json(title_group),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/torrent_handler.rs
+++ b/src/handlers/torrent_handler.rs
@@ -1,20 +1,20 @@
 use actix_multipart::form::MultipartForm;
 use actix_web::{HttpResponse, web};
-use sqlx::PgPool;
 
 use crate::{
+    Arcadia,
     models::{torrent::UploadedTorrent, user::User},
     repositories::torrent_repository::create_torrent,
 };
 
 pub async fn upload_torrent(
     form: MultipartForm<UploadedTorrent>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
     // TODO : check if user can upload
 
-    match create_torrent(&pool, &form, &current_user).await {
+    match create_torrent(&arc.pool, &form, &current_user).await {
         Ok(created_torrent) => HttpResponse::Created().json(serde_json::json!(created_torrent)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/torrent_request_handler.rs
+++ b/src/handlers/torrent_request_handler.rs
@@ -1,16 +1,16 @@
 use crate::{
+    Arcadia,
     models::{torrent_request::UserCreatedTorrentRequest, user::User},
     repositories::torrent_request_repository::create_torrent_request,
 };
 use actix_web::{HttpResponse, web};
-use sqlx::PgPool;
 
 pub async fn add_torrent_request(
     torrent_request: web::Json<UserCreatedTorrentRequest>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_torrent_request(&pool, &torrent_request, &current_user).await {
+    match create_torrent_request(&arc.pool, &torrent_request, &current_user).await {
         Ok(created_torrent_request) => {
             HttpResponse::Created().json(serde_json::json!(created_torrent_request))
         }

--- a/src/handlers/torrent_request_vote_handler.rs
+++ b/src/handlers/torrent_request_vote_handler.rs
@@ -1,16 +1,16 @@
 use crate::{
+    Arcadia,
     models::{torrent_request_vote::UserCreatedTorrentRequestVote, user::User},
     repositories::torrent_request_vote_repository::create_torrent_request_vote,
 };
 use actix_web::{HttpResponse, web};
-use sqlx::PgPool;
 
 pub async fn add_torrent_request_vote(
     torrent_request_vote: web::Json<UserCreatedTorrentRequestVote>,
-    pool: web::Data<PgPool>,
+    arc: web::Data<Arcadia>,
     current_user: User,
 ) -> HttpResponse {
-    match create_torrent_request_vote(&pool, &torrent_request_vote, &current_user).await {
+    match create_torrent_request_vote(&arc.pool, &torrent_request_vote, &current_user).await {
         Ok(created_artist) => HttpResponse::Created().json(serde_json::json!(created_artist)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/handlers/user_handler.rs
+++ b/src/handlers/user_handler.rs
@@ -1,15 +1,14 @@
-use crate::{models::user::User, repositories::user_repository::find_user_by_id};
+use crate::{Arcadia, models::user::User, repositories::user_repository::find_user_by_id};
 use actix_web::{HttpResponse, web};
 use serde::Deserialize;
-use sqlx::PgPool;
 
 #[derive(Debug, Deserialize)]
 pub struct GetUserQuery {
     id: i64,
 }
 
-pub async fn get_user(pool: web::Data<PgPool>, query: web::Query<GetUserQuery>) -> HttpResponse {
-    match find_user_by_id(&pool, &query.id).await {
+pub async fn get_user(arc: web::Data<Arcadia>, query: web::Query<GetUserQuery>) -> HttpResponse {
+    match find_user_by_id(&arc.pool, &query.id).await {
         Ok(user) => HttpResponse::Created().json(serde_json::json!(user)),
         Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
             "error": err.to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,7 @@ pub mod handlers;
 pub mod models;
 pub mod repositories;
 pub mod routes;
+
+pub struct Arcadia {
+    pub pool: sqlx::PgPool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use routes::init;
 use sqlx::postgres::PgPoolOptions;
 use std::env;
 
+use arcadia_index::Arcadia;
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv::from_filename(".env.local").ok();
@@ -29,7 +31,7 @@ async fn main() -> std::io::Result<()> {
         let cors = Cors::permissive();
         App::new()
             .wrap(cors)
-            .app_data(Data::new(pool.clone()))
+            .app_data(Data::new(Arcadia { pool: pool.clone() }))
             .configure(init) // Initialize routes
     })
     .bind(format!("{}:{}", host, port))?

--- a/src/repositories/artist_repository.rs
+++ b/src/repositories/artist_repository.rs
@@ -3,13 +3,12 @@ use crate::models::{
     title_group::{AffiliatedArtist, UserCreatedAffiliatedArtist},
     user::User,
 };
-use actix_web::web;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_artist(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     artist: &UserCreatedArtist,
     current_user: &User,
 ) -> Result<Artist, Box<dyn Error>> {
@@ -25,7 +24,7 @@ pub async fn create_artist(
         artist.pictures.as_deref(),
         current_user.id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match created_artist {
@@ -42,7 +41,7 @@ pub async fn create_artist(
 }
 
 pub async fn create_artists_affiliation(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     artists: &Vec<UserCreatedAffiliatedArtist>,
     current_user: &User,
 ) -> Result<Vec<AffiliatedArtist>, Box<dyn Error>> {
@@ -74,7 +73,7 @@ pub async fn create_artists_affiliation(
             .bind(current_user.id);
     }
 
-    match q.fetch_all(pool.as_ref()).await {
+    match q.fetch_all(pool).await {
         Ok(affiliated_artists) => Ok(affiliated_artists),
         Err(e) => {
             println!("{:#?}", e);
@@ -92,7 +91,7 @@ pub async fn create_artists_affiliation(
 }
 
 pub async fn find_artist_publications(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     artist_id: &i32,
 ) -> Result<Value, Box<dyn Error>> {
     // TODO: only select the required info about the torrents (mediainfo etc is not necessary)
@@ -138,7 +137,7 @@ FROM artist_title_groups tg
 LEFT JOIN torrent_request_data trd ON trd.title_group_id = tg.id;"#,
         artist_id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match artist_publications {

--- a/src/repositories/auth_repository.rs
+++ b/src/repositories/auth_repository.rs
@@ -13,7 +13,7 @@ use sqlx::{PgPool, types::ipnetwork::IpNetwork};
 use std::{env, error::Error};
 
 pub async fn create_user(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     user: &Register,
     from_ip: IpNetwork,
     password_hash: &str,
@@ -32,7 +32,7 @@ pub async fn create_user(
         password_hash,
         from_ip
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match registered_user {
@@ -47,7 +47,7 @@ pub async fn create_user(
                     registered_user.id,
                     invitation.id
                 )
-                .execute(pool.get_ref())
+                .execute(pool)
                 .await;
             }
 
@@ -63,10 +63,7 @@ pub async fn create_user(
     }
 }
 
-pub async fn find_user_with_password(
-    pool: &web::Data<PgPool>,
-    user: &Login,
-) -> Result<User, Box<dyn Error>> {
+pub async fn find_user_with_password(pool: &PgPool, user: &Login) -> Result<User, Box<dyn Error>> {
     let result = sqlx::query_as!(
         User,
         r#"
@@ -75,7 +72,7 @@ pub async fn find_user_with_password(
         "#,
         user.username
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match result {

--- a/src/repositories/edition_group_repository.rs
+++ b/src/repositories/edition_group_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     edition_group::{EditionGroup, UserCreatedEditionGroup},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_edition_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     edition_group_form: &UserCreatedEditionGroup,
     current_user: &User,
 ) -> Result<EditionGroup, Box<dyn Error>> {
@@ -28,7 +27,7 @@ pub async fn create_edition_group(
         .bind(&edition_group_form.external_links)
         .bind(&edition_group_form.source)
         .bind(&edition_group_form.additional_information)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_edition_group {

--- a/src/repositories/invitation_repository.rs
+++ b/src/repositories/invitation_repository.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 
-use actix_web::web;
 use rand::{
     distr::{Alphanumeric, SampleString},
     rng,
@@ -13,7 +12,7 @@ use crate::models::{
 };
 
 pub async fn create_invitation(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     invitation: &SentInvitation,
     current_user: &User,
 ) -> Result<Invitation, Box<dyn Error>> {
@@ -40,7 +39,7 @@ pub async fn create_invitation(
         current_user.id,
         invitation.receiver_email
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match sent_invitation {
@@ -57,7 +56,7 @@ pub async fn create_invitation(
 }
 
 pub async fn does_invitation_exist(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     invitation_key: &str,
 ) -> Result<Invitation, Box<dyn Error>> {
     // TODO: test and handle expiration
@@ -68,7 +67,7 @@ pub async fn does_invitation_exist(
         "#,
         invitation_key
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match invitation {
@@ -85,7 +84,7 @@ pub async fn does_invitation_exist(
 }
 
 pub async fn set_invitations_available(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     amount: i16,
     current_user: &User,
 ) -> Result<(), Box<dyn Error>> {
@@ -97,7 +96,7 @@ pub async fn set_invitations_available(
         amount,
         current_user.id
     )
-    .execute(pool.get_ref())
+    .execute(pool)
     .await;
 
     match result {

--- a/src/repositories/master_group_repository.rs
+++ b/src/repositories/master_group_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     master_group::{MasterGroup, UserCreatedMasterGroup},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_master_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     master_group_form: &UserCreatedMasterGroup,
     current_user: &User,
 ) -> Result<MasterGroup, Box<dyn Error>> {
@@ -29,7 +28,7 @@ pub async fn create_master_group(
         // .bind(&master_group_form.fan_arts)
         // .bind(&master_group_form.category)
         // .bind(&master_group_form.tags)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_master_group {

--- a/src/repositories/notification_repository.rs
+++ b/src/repositories/notification_repository.rs
@@ -1,9 +1,8 @@
-use actix_web::web;
 use sqlx::{PgPool, postgres::PgQueryResult};
 use std::error::Error;
 
 pub async fn notify_users(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     event: &str,
     item_id: &i64,
     title: &str,
@@ -32,7 +31,7 @@ pub async fn notify_users(
                 title,
                 message
             )
-            .execute(pool.get_ref())
+            .execute(pool)
             .await;
         }
         _ => {

--- a/src/repositories/series_repository.rs
+++ b/src/repositories/series_repository.rs
@@ -2,13 +2,12 @@ use crate::models::{
     series::{Series, UserCreatedSeries},
     user::User,
 };
-use actix_web::web;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_series(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     series: &UserCreatedSeries,
     current_user: &User,
 ) -> Result<Series, Box<dyn Error>> {
@@ -26,7 +25,7 @@ pub async fn create_series(
         &series.banners,
         &series.tags
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match created_series {
@@ -42,10 +41,7 @@ pub async fn create_series(
     }
 }
 
-pub async fn find_series(
-    pool: &web::Data<PgPool>,
-    series_id: &i64,
-) -> Result<Value, Box<dyn Error>> {
+pub async fn find_series(pool: &PgPool, series_id: &i64) -> Result<Value, Box<dyn Error>> {
     let found_series = sqlx::query!(
         r#"
             WITH title_group_data AS (
@@ -82,7 +78,7 @@ pub async fn find_series(
         "#,
         series_id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match found_series {

--- a/src/repositories/subscriptions_repository.rs
+++ b/src/repositories/subscriptions_repository.rs
@@ -1,10 +1,9 @@
 use crate::models::user::User;
-use actix_web::web;
 use sqlx::{PgPool, postgres::PgQueryResult};
 use std::error::Error;
 
 pub async fn create_subscription(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     item_id: &i64,
     item: &str,
     current_user: &User,
@@ -20,7 +19,7 @@ pub async fn create_subscription(
                 item_id,
                 current_user.id
             )
-            .execute(pool.get_ref())
+            .execute(pool)
             .await;
         }
         _ => {
@@ -42,7 +41,7 @@ pub async fn create_subscription(
 }
 
 pub async fn delete_subscription(
-    pool: &web::Data<sqlx::PgPool>,
+    pool: &PgPool,
     item_id: &i64,
     item: &str,
     current_user: &User,
@@ -58,7 +57,7 @@ pub async fn delete_subscription(
                 item_id,
                 current_user.id
             )
-            .execute(pool.get_ref())
+            .execute(pool)
             .await;
         }
         _ => {

--- a/src/repositories/title_group_comment_repository.rs
+++ b/src/repositories/title_group_comment_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     title_group_comment::{TitleGroupComment, UserCreatedTitleGroupComment},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_title_group_comment(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_comment: &UserCreatedTitleGroupComment,
     current_user: &User,
 ) -> Result<TitleGroupComment, Box<dyn Error>> {
@@ -24,7 +23,7 @@ pub async fn create_title_group_comment(
             .bind(&current_user.id)
             .bind(&title_group_comment.refers_to_torrent_id)
             .bind(&title_group_comment.answers_to_comment_id)
-            .fetch_one(pool.get_ref())
+            .fetch_one(pool)
             .await;
 
     match created_title_group_comment {

--- a/src/repositories/title_group_repository.rs
+++ b/src/repositories/title_group_repository.rs
@@ -2,13 +2,12 @@ use crate::models::{
     title_group::{TitleGroup, UserCreatedTitleGroup},
     user::User,
 };
-use actix_web::web;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_title_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_form: &UserCreatedTitleGroup,
     current_user: &User,
 ) -> Result<TitleGroup, Box<dyn Error>> {
@@ -35,7 +34,7 @@ pub async fn create_title_group(
         .bind(&title_group_form.tags)
         .bind(&title_group_form.tagline)
         // .bind(&title_group_form.public_ratings)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_title_group {
@@ -52,7 +51,7 @@ pub async fn create_title_group(
 }
 
 pub async fn find_title_group(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_id: i64,
     current_user: &User,
 ) -> Result<Value, Box<dyn Error>> {
@@ -142,7 +141,7 @@ LEFT JOIN series_data sd ON sd.title_group_id = tg.id
 LEFT JOIN torrent_request_data trd ON trd.title_group_id = tg.id
 LEFT JOIN subscription_data sud ON sud.id = tg.id
 WHERE tg.id = $2;"#, current_user.id, title_group_id)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match title_group {
@@ -158,7 +157,7 @@ WHERE tg.id = $2;"#, current_user.id, title_group_id)
     }
 }
 pub async fn find_lite_title_group_info(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     title_group_id: i64,
 ) -> Result<Value, Box<dyn Error>> {
     let title_group = sqlx::query!(
@@ -184,7 +183,7 @@ WHERE tg.id = $1
 GROUP BY tg.id;"#,
         title_group_id
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match title_group {

--- a/src/repositories/torrent_repository.rs
+++ b/src/repositories/torrent_repository.rs
@@ -2,7 +2,6 @@ use crate::models::{
     torrent::{Features, Torrent, UploadedTorrent},
     user::User,
 };
-use actix_web::web;
 use bip_metainfo::Metainfo;
 use serde_json::json;
 use sqlx::PgPool;
@@ -18,7 +17,7 @@ struct LiteTitleGroupInfo {
 }
 
 pub async fn create_torrent(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     torrent_form: &UploadedTorrent,
     current_user: &User,
 ) -> Result<Torrent, Box<dyn Error>> {
@@ -126,7 +125,7 @@ pub async fn create_torrent(
         .bind(torrent_form.video_resolution.as_deref())
         .bind(&*torrent_form.container)
         .bind(torrent_form.language.as_deref())
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     // TODO: edit the torrent file with proper flags, remove announce url and store it to the disk
@@ -141,7 +140,7 @@ pub async fn create_torrent(
         WHERE edition_groups.id = $1",
                 &torrent_form.edition_group_id.0
             )
-            .fetch_one(&***pool)
+            .fetch_one(pool)
             .await?;
             let _ = notify_users(
                 pool,

--- a/src/repositories/torrent_request_repository.rs
+++ b/src/repositories/torrent_request_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     torrent_request::{TorrentRequest, UserCreatedTorrentRequest},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_torrent_request(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     torrent_request: &UserCreatedTorrentRequest,
     current_user: &User,
 ) -> Result<TorrentRequest, Box<dyn Error>> {
@@ -38,7 +37,7 @@ pub async fn create_torrent_request(
         .bind(&torrent_request.video_resolution)
         .bind(&torrent_request.bounty_upload)
         .bind(&torrent_request.bounty_bonus_points)
-        .fetch_one(pool.get_ref())
+        .fetch_one(pool)
         .await;
 
     match created_torrent_request {

--- a/src/repositories/torrent_request_vote_repository.rs
+++ b/src/repositories/torrent_request_vote_repository.rs
@@ -2,12 +2,11 @@ use crate::models::{
     torrent_request_vote::{TorrentRequestVote, UserCreatedTorrentRequestVote},
     user::User,
 };
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
 pub async fn create_torrent_request_vote(
-    pool: &web::Data<PgPool>,
+    pool: &PgPool,
     torrent_request_vote: &UserCreatedTorrentRequestVote,
     current_user: &User,
 ) -> Result<TorrentRequestVote, Box<dyn Error>> {
@@ -51,7 +50,7 @@ FROM inserted_vote;"#;
             .bind(&current_user.id)
             .bind(&torrent_request_vote.bounty_upload)
             .bind(&torrent_request_vote.bounty_bonus_points)
-            .fetch_one(pool.get_ref())
+            .fetch_one(pool)
             .await;
 
     match created_torrent_request_vote {

--- a/src/repositories/user_repository.rs
+++ b/src/repositories/user_repository.rs
@@ -1,12 +1,8 @@
 use crate::models::user::{PublicUser, User};
-use actix_web::web;
 use sqlx::PgPool;
 use std::error::Error;
 
-pub async fn find_user_by_username(
-    pool: &web::Data<PgPool>,
-    username: &str,
-) -> Result<User, Box<dyn Error>> {
+pub async fn find_user_by_username(pool: &PgPool, username: &str) -> Result<User, Box<dyn Error>> {
     let result = sqlx::query_as!(
         User,
         r#"
@@ -15,7 +11,7 @@ pub async fn find_user_by_username(
         "#,
         username
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match result {
@@ -29,10 +25,7 @@ pub async fn find_user_by_username(
         }
     }
 }
-pub async fn find_user_by_id(
-    pool: &web::Data<PgPool>,
-    id: &i64,
-) -> Result<PublicUser, Box<dyn Error>> {
+pub async fn find_user_by_id(pool: &PgPool, id: &i64) -> Result<PublicUser, Box<dyn Error>> {
     // TODO: use id BIGINT PRIMARY KEY GENERATED ALWAYS AS DEFAULT
     let result = sqlx::query_as!(
         PublicUser,
@@ -71,7 +64,7 @@ pub async fn find_user_by_id(
         "#,
         *id as i32
     )
-    .fetch_one(pool.get_ref())
+    .fetch_one(pool)
     .await;
 
     match result {

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -8,6 +8,7 @@ use actix_web::{
     },
     test, web,
 };
+use arcadia_index::Arcadia;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 
@@ -17,7 +18,7 @@ async fn create_test_app(
     // TODO: CORS?
     test::init_service(
         App::new()
-            .app_data(web::Data::new(pool))
+            .app_data(web::Data::new(Arcadia { pool }))
             .configure(arcadia_index::routes::init),
     )
     .await


### PR DESCRIPTION
Currently, only PgPool is used as app-state runtime data, but this is
limited.  Prepare to allow for additional fields to be added by lifting
out a top-level `Arcadia` type (currently only holding the `PgPool`).

This is preparation for reifying additional state data to facilitate
testing (namely: open signup state).

Note: stacks on #10 