### PR TITLE
handlers: rework error management

### DIFF
--- a/src/handlers/artist_handler.rs
+++ b/src/handlers/artist_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{artist::UserCreatedArtist, title_group::UserCreatedAffiliatedArtist, user::User},
     repositories::artist_repository::{
         create_artist, create_artists_affiliation, find_artist_publications,
@@ -12,28 +12,20 @@ pub async fn add_artist(
     artist: web::Json<UserCreatedArtist>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_artist(&arc.pool, &artist, &current_user).await {
-        Ok(created_artist) => HttpResponse::Created().json(serde_json::json!(created_artist)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let artist = create_artist(&arc.pool, &artist, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(artist))
 }
 
 pub async fn add_affiliated_artists(
     artists: web::Json<Vec<UserCreatedAffiliatedArtist>>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_artists_affiliation(&arc.pool, &artists, &current_user).await {
-        Ok(created_affiliations) => {
-            HttpResponse::Created().json(serde_json::json!(created_affiliations))
-        }
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let affiliation = create_artists_affiliation(&arc.pool, &artists, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(affiliation))
 }
 
 #[derive(Debug, Deserialize)]
@@ -44,13 +36,8 @@ pub struct GetArtistPublicationsQuery {
 pub async fn get_artist_publications(
     query: web::Query<GetArtistPublicationsQuery>,
     arc: web::Data<Arcadia>,
-) -> HttpResponse {
-    match find_artist_publications(&arc.pool, &query.id).await {
-        Ok(artist_publications) => {
-            HttpResponse::Created().json(serde_json::json!(artist_publications))
-        }
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let artist_publication = find_artist_publications(&arc.pool, &query.id).await?;
+
+    Ok(HttpResponse::Created().json(artist_publication))
 }

--- a/src/handlers/edition_group_handler.rs
+++ b/src/handlers/edition_group_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{edition_group::UserCreatedEditionGroup, user::User},
     repositories::edition_group_repository::create_edition_group,
 };
@@ -9,11 +9,8 @@ pub async fn add_edition_group(
     form: web::Json<UserCreatedEditionGroup>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_edition_group(&arc.pool, &form, &current_user).await {
-        Ok(edition_group) => HttpResponse::Created().json(serde_json::json!(edition_group)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let edition_group = create_edition_group(&arc.pool, &form, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(edition_group))
 }

--- a/src/handlers/invitation_handler.rs
+++ b/src/handlers/invitation_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Error, Result,
     models::{invitation::SentInvitation, user::User},
     repositories::invitation_repository::create_invitation,
 };
@@ -9,19 +9,14 @@ pub async fn send_invitation(
     invitation: web::Json<SentInvitation>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
+) -> Result<HttpResponse> {
     if current_user.invitations == 0 {
-        return HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": "you currently have 0 invitation available"
-        }));
+        return Err(Error::NoInvitationsAvailable);
     }
 
     // TODO: send email to the user who receives the invite
 
-    match create_invitation(&arc.pool, &invitation, &current_user).await {
-        Ok(user) => HttpResponse::Created().json(serde_json::json!(user)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+    let invitation = create_invitation(&arc.pool, &invitation, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(invitation))
 }

--- a/src/handlers/master_group_handler.rs
+++ b/src/handlers/master_group_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{master_group::UserCreatedMasterGroup, user::User},
     repositories::master_group_repository::create_master_group,
 };
@@ -9,11 +9,8 @@ pub async fn add_master_group(
     form: web::Json<UserCreatedMasterGroup>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_master_group(&arc.pool, &form, &current_user).await {
-        Ok(master_group) => HttpResponse::Created().json(serde_json::json!(master_group)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let master_group = create_master_group(&arc.pool, &form, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(master_group))
 }

--- a/src/handlers/series_handler.rs
+++ b/src/handlers/series_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{series::UserCreatedSeries, user::User},
     repositories::series_repository::{create_series, find_series},
 };
@@ -10,13 +10,10 @@ pub async fn add_series(
     serie: web::Json<UserCreatedSeries>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_series(&arc.pool, &serie, &current_user).await {
-        Ok(created_serie) => HttpResponse::Created().json(serde_json::json!(created_serie)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let series = create_series(&arc.pool, &serie, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(series))
 }
 
 #[derive(Debug, Deserialize)]
@@ -27,11 +24,8 @@ pub struct GetSeriesQuery {
 pub async fn get_series(
     arc: web::Data<Arcadia>,
     query: web::Query<GetSeriesQuery>,
-) -> HttpResponse {
-    match find_series(&arc.pool, &query.id).await {
-        Ok(title_group) => HttpResponse::Ok().json(title_group),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let series = find_series(&arc.pool, &query.id).await?;
+
+    Ok(HttpResponse::Ok().json(series))
 }

--- a/src/handlers/subscriptions_handler.rs
+++ b/src/handlers/subscriptions_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::user::User,
     repositories::subscriptions_repository::{create_subscription, delete_subscription},
 };
@@ -16,13 +16,10 @@ pub async fn add_subscription(
     query: web::Query<AddSubscriptionQuery>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_subscription(&arc.pool, &query.item_id, &query.item, &current_user).await {
-        Ok(_) => HttpResponse::Created().json(serde_json::json!({"result": "success"})),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    create_subscription(&arc.pool, &query.item_id, &query.item, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(serde_json::json!({"result": "success"})))
 }
 
 pub type RemoveSubscriptionQuery = AddSubscriptionQuery;
@@ -31,11 +28,8 @@ pub async fn remove_subscription(
     query: web::Query<RemoveSubscriptionQuery>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match delete_subscription(&arc.pool, &query.item_id, &query.item, &current_user).await {
-        Ok(_) => HttpResponse::Created().json(serde_json::json!({"result": "success"})),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    delete_subscription(&arc.pool, &query.item_id, &query.item, &current_user).await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({"result": "success"})))
 }

--- a/src/handlers/title_group_comment_handler.rs
+++ b/src/handlers/title_group_comment_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{title_group_comment::UserCreatedTitleGroupComment, user::User},
     repositories::title_group_comment_repository::create_title_group_comment,
 };
@@ -9,11 +9,9 @@ pub async fn add_title_group_comment(
     comment: web::Json<UserCreatedTitleGroupComment>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_title_group_comment(&arc.pool, &comment, &current_user).await {
-        Ok(created_comment) => HttpResponse::Created().json(serde_json::json!(created_comment)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let title_group_comment =
+        create_title_group_comment(&arc.pool, &comment, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(title_group_comment))
 }

--- a/src/handlers/title_group_handler.rs
+++ b/src/handlers/title_group_handler.rs
@@ -2,7 +2,7 @@ use actix_web::{HttpResponse, web};
 use serde::Deserialize;
 
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{title_group::UserCreatedTitleGroup, user::User},
     repositories::title_group_repository::{
         create_title_group, find_lite_title_group_info, find_title_group,
@@ -13,13 +13,10 @@ pub async fn add_title_group(
     form: web::Json<UserCreatedTitleGroup>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_title_group(&arc.pool, &form, &current_user).await {
-        Ok(title_group) => HttpResponse::Created().json(serde_json::json!(title_group)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let title_group = create_title_group(&arc.pool, &form, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(title_group))
 }
 
 #[derive(Debug, Deserialize)]
@@ -31,13 +28,10 @@ pub async fn get_title_group(
     arc: web::Data<Arcadia>,
     query: web::Query<GetTitleGroupQuery>,
     current_user: User,
-) -> HttpResponse {
-    match find_title_group(&arc.pool, query.id, &current_user).await {
-        Ok(title_group) => HttpResponse::Ok().json(title_group),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let title_group = find_title_group(&arc.pool, query.id, &current_user).await?;
+
+    Ok(HttpResponse::Ok().json(title_group))
 }
 
 pub type GetLiteTitleGroupInfoQuery = GetTitleGroupQuery;
@@ -45,11 +39,8 @@ pub type GetLiteTitleGroupInfoQuery = GetTitleGroupQuery;
 pub async fn get_lite_title_group_info(
     arc: web::Data<Arcadia>,
     query: web::Query<GetLiteTitleGroupInfoQuery>,
-) -> HttpResponse {
-    match find_lite_title_group_info(&arc.pool, query.id).await {
-        Ok(title_group) => HttpResponse::Ok().json(title_group),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let title_group = find_lite_title_group_info(&arc.pool, query.id).await?;
+
+    Ok(HttpResponse::Ok().json(title_group))
 }

--- a/src/handlers/torrent_handler.rs
+++ b/src/handlers/torrent_handler.rs
@@ -2,7 +2,7 @@ use actix_multipart::form::MultipartForm;
 use actix_web::{HttpResponse, web};
 
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{torrent::UploadedTorrent, user::User},
     repositories::torrent_repository::create_torrent,
 };
@@ -11,13 +11,10 @@ pub async fn upload_torrent(
     form: MultipartForm<UploadedTorrent>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
+) -> Result<HttpResponse> {
     // TODO : check if user can upload
 
-    match create_torrent(&arc.pool, &form, &current_user).await {
-        Ok(created_torrent) => HttpResponse::Created().json(serde_json::json!(created_torrent)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+    let torrent = create_torrent(&arc.pool, &form, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(torrent))
 }

--- a/src/handlers/torrent_request_handler.rs
+++ b/src/handlers/torrent_request_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{torrent_request::UserCreatedTorrentRequest, user::User},
     repositories::torrent_request_repository::create_torrent_request,
 };
@@ -9,13 +9,9 @@ pub async fn add_torrent_request(
     torrent_request: web::Json<UserCreatedTorrentRequest>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_torrent_request(&arc.pool, &torrent_request, &current_user).await {
-        Ok(created_torrent_request) => {
-            HttpResponse::Created().json(serde_json::json!(created_torrent_request))
-        }
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let torrent_request =
+        create_torrent_request(&arc.pool, &torrent_request, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(torrent_request))
 }

--- a/src/handlers/torrent_request_vote_handler.rs
+++ b/src/handlers/torrent_request_vote_handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Arcadia,
+    Arcadia, Result,
     models::{torrent_request_vote::UserCreatedTorrentRequestVote, user::User},
     repositories::torrent_request_vote_repository::create_torrent_request_vote,
 };
@@ -9,11 +9,8 @@ pub async fn add_torrent_request_vote(
     torrent_request_vote: web::Json<UserCreatedTorrentRequestVote>,
     arc: web::Data<Arcadia>,
     current_user: User,
-) -> HttpResponse {
-    match create_torrent_request_vote(&arc.pool, &torrent_request_vote, &current_user).await {
-        Ok(created_artist) => HttpResponse::Created().json(serde_json::json!(created_artist)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+) -> Result<HttpResponse> {
+    let vote = create_torrent_request_vote(&arc.pool, &torrent_request_vote, &current_user).await?;
+
+    Ok(HttpResponse::Created().json(vote))
 }

--- a/src/handlers/user_handler.rs
+++ b/src/handlers/user_handler.rs
@@ -1,4 +1,4 @@
-use crate::{Arcadia, models::user::User, repositories::user_repository::find_user_by_id};
+use crate::{Arcadia, Result, models::user::User, repositories::user_repository::find_user_by_id};
 use actix_web::{HttpResponse, web};
 use serde::Deserialize;
 
@@ -7,17 +7,16 @@ pub struct GetUserQuery {
     id: i64,
 }
 
-pub async fn get_user(arc: web::Data<Arcadia>, query: web::Query<GetUserQuery>) -> HttpResponse {
-    match find_user_by_id(&arc.pool, &query.id).await {
-        Ok(user) => HttpResponse::Created().json(serde_json::json!(user)),
-        Err(err) => HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": err.to_string()
-        })),
-    }
+pub async fn get_user(
+    arc: web::Data<Arcadia>,
+    query: web::Query<GetUserQuery>,
+) -> Result<HttpResponse> {
+    let user = find_user_by_id(&arc.pool, &query.id).await?;
+
+    Ok(HttpResponse::Created().json(user))
 }
 
-pub async fn get_me(current_user: User) -> HttpResponse {
-    let mut current_user = current_user;
+pub async fn get_me(mut current_user: User) -> HttpResponse {
     current_user.password_hash = String::from("");
-    HttpResponse::Ok().json(serde_json::json!(current_user))
+    HttpResponse::Ok().json(current_user)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,15 @@ pub enum Error {
     #[error("invalid invitation key")]
     InvitationKeyInvalid,
 
+    #[error("invitation key required")]
+    InvitationKeyRequired,
+
+    #[error("invitation key already used")]
+    InvitationKeyAlreadyUsed,
+
+    #[error("no invitations available")]
+    NoInvitationsAvailable,
+
     #[error("user '{0}' not found")]
     UserNotFound(String),
 
@@ -97,3 +106,16 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl actix_web::ResponseError for Error {
+    #[inline]
+    fn status_code(&self) -> actix_web::http::StatusCode {
+        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    fn error_response(&self) -> actix_web::HttpResponse {
+        actix_web::HttpResponse::build(self.status_code()).json(serde_json::json!({
+            "error": format!("{self}"),
+        }))
+    }
+}


### PR DESCRIPTION
Step 2 in reworking errors, this changes fallible handlers to use the top-level Error type, and reworks the implementations to use '?' for short-circuiting.

It also implements `actix_web::ResponseError` to generate JSON error responses for the frontend. The implementation of `status_code()` can be adjusted to generate appropriate status codes based on error (to come).