### PR TITLE
externaldb: initial tmdb support

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,6 @@ DATABASE_URL=postgresql://${POSTGRESQL_USER}:${POSTGRESQL_PASSWORD}@${POSTGRESQL
 # arcadia config
 
 ARCADIA_OPEN_SIGNUPS=true
+
+# Required for TMDB access, must create a new account with themoviedb.org
+# TMDB_API_TOKEN="your token"

--- a/src/handlers/scrapers/mod.rs
+++ b/src/handlers/scrapers/mod.rs
@@ -1,1 +1,2 @@
 pub mod open_library;
+pub mod tmdb;

--- a/src/handlers/scrapers/tmdb.rs
+++ b/src/handlers/scrapers/tmdb.rs
@@ -1,0 +1,215 @@
+use crate::{
+    Result,
+    models::title_group::{ContentType, UserCreatedTitleGroup, create_default_title_group},
+};
+use actix_web::{HttpResponse, web};
+use serde::{Deserialize, de::DeserializeOwned};
+
+#[derive(Debug, Deserialize)]
+struct Movie {
+    //id: u32,
+    title: String,
+    overview: String,
+    release_date: String,
+    //vote_average: f64,
+    //vote_count: u32,
+    original_language: String,
+    original_title: String,
+    //genres: Vec<Genre>,
+    poster_path: Option<String>,
+    //backdrop_path: Option<String>,
+    //production_companies: Vec<ProductionCompany>,
+    //runtime: Option<u32>,
+    //status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TvShow {
+    //id: u64,
+    name: String,
+    overview: String,
+    first_air_date: String,
+    //last_air_date: String,
+    //number_of_seasons: u32,
+    //number_of_episodes: u32,
+    //status: String,
+    //genres: Vec<Genre>,
+    homepage: Option<String>,
+    //backdrop_path: Option<String>,
+    poster_path: Option<String>,
+    //vote_average: f32,
+    //vote_count: u32,
+}
+
+//#[derive(Debug, Deserialize)]
+//struct Genre {
+//    id: u32,
+//    name: String,
+//}
+
+//#[derive(Debug, Deserialize)]
+//struct ProductionCompany {
+//    id: u32,
+//    name: String,
+//    logo_path: Option<String>,
+//    origin_country: String,
+//}
+
+#[derive(Debug, Deserialize)]
+struct Configuration {
+    images: Images,
+}
+
+#[derive(Debug, Deserialize)]
+struct Images {
+    base_url: String,
+    //secure_base_url: String,
+    poster_sizes: Vec<String>,
+    //backdrop_sizes: Vec<String>,
+    //profile_sizes: Vec<String>,
+    //logo_sizes: Vec<String>,
+    //still_sizes: Vec<String>,
+}
+
+struct Tmdb {
+    client: reqwest::Client,
+    bearer: String,
+    config: Configuration,
+}
+
+const BASE_URL: &'static str = "https://api.themoviedb.org/3";
+
+impl Tmdb {
+    async fn new(bearer: impl Into<String>) -> Result<Self> {
+        let client = reqwest::Client::new();
+        let bearer = bearer.into();
+
+        let config = client
+            .get(format!("{}/configuration", BASE_URL))
+            .bearer_auth(&bearer)
+            .send()
+            .await?
+            .json::<Configuration>()
+            .await?;
+
+        Ok(Tmdb {
+            client,
+            bearer,
+            config,
+        })
+    }
+
+    async fn call_endpoint<T: DeserializeOwned>(&self, endpoint: impl AsRef<str>) -> Result<T> {
+        let resp = self
+            .client
+            .get(endpoint.as_ref())
+            .bearer_auth(&self.bearer)
+            .send()
+            .await?
+            .json::<T>()
+            .await?;
+
+        Ok(resp)
+    }
+
+    async fn movie_by_id(&self, id: u32) -> Result<Movie> {
+        self.call_endpoint::<Movie>(format!("{}/movie/{}", BASE_URL, id))
+            .await
+    }
+
+    async fn tvshow_by_id(&self, id: u32) -> Result<TvShow> {
+        self.call_endpoint::<TvShow>(format!("{}/tv/{}", BASE_URL, id))
+            .await
+    }
+
+    fn get_image_urls(&self, path: impl Into<String>) -> impl Iterator<Item = String> {
+        let path = path.into();
+        self.config
+            .images
+            .poster_sizes
+            .iter()
+            .map(move |sz| format!("{}{}{}", self.config.images.base_url, sz, path))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TmdbQuery {
+    id: u32,
+}
+
+pub async fn get_tmdb_movie_data(query: web::Query<TmdbQuery>) -> Result<HttpResponse> {
+    let token = std::env::var("TMDB_API_TOKEN").expect("TMDB_API_TOKEN must be set");
+
+    // TODO: create this only once.
+    let tmdb = Tmdb::new(token).await?;
+
+    let movie = tmdb.movie_by_id(query.id).await?;
+
+    let name_aliases = if movie.title != movie.original_title {
+        vec![movie.original_title]
+    } else {
+        vec![]
+    };
+
+    let covers = movie
+        .poster_path
+        .as_ref()
+        .map(|p| tmdb.get_image_urls(p).collect());
+
+    let original_release_date = chrono::NaiveDate::parse_from_str(&movie.release_date, "%Y-%m-%d")
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+
+    let title_group = UserCreatedTitleGroup {
+        name: movie.title,
+        name_aliases,
+        description: movie.overview,
+        original_language: Some(movie.original_language),
+        covers,
+        external_links: vec![format!("https://www.themoviedb.org/movie/{}", query.id)],
+        content_type: ContentType::Movie,
+        original_release_date,
+        ..create_default_title_group()
+    };
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "title_group": title_group })))
+}
+
+pub async fn get_tmdb_tv_data(query: web::Query<TmdbQuery>) -> Result<HttpResponse> {
+    let token = std::env::var("TMDB_API_TOKEN").expect("TMDB_API_TOKEN must be set");
+
+    // TODO: create this only once.
+    let tmdb = Tmdb::new(token).await?;
+
+    let tvshow = tmdb.tvshow_by_id(query.id).await?;
+
+    let covers = tvshow
+        .poster_path
+        .as_ref()
+        .map(|p| tmdb.get_image_urls(p).collect());
+
+    let mut external_links = vec![format!("https://www.themoviedb.org/tv/{}", query.id)];
+
+    if let Some(homepage) = tvshow.homepage {
+        external_links.push(homepage);
+    }
+
+    let original_release_date =
+        chrono::NaiveDate::parse_from_str(&tvshow.first_air_date, "%Y-%m-%d")
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+
+    let title_group = UserCreatedTitleGroup {
+        name: tvshow.name,
+        description: tvshow.overview,
+        covers,
+        external_links: vec![format!("https://www.themoviedb.org/tv/{}", query.id)],
+        content_type: ContentType::TVShow,
+        original_release_date,
+        ..create_default_title_group()
+    };
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "title_group": title_group })))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub enum Error {
 
     #[error("not enough upload to place this bounty")]
     InsufficientUploadForBounty,
+
+    #[error("unexpected third party response")]
+    UnexpectedThirdPartyResponse(#[from] reqwest::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,6 +7,7 @@ use crate::handlers::{
     invitation_handler::send_invitation,
     master_group_handler::add_master_group,
     scrapers::open_library::get_open_library_data,
+    scrapers::tmdb::{get_tmdb_movie_data, get_tmdb_tv_data},
     series_handler::{add_series, get_series},
     subscriptions_handler::{add_subscription, remove_subscription},
     title_group_comment_handler::add_title_group_comment,
@@ -59,6 +60,11 @@ pub fn init(cfg: &mut web::ServiceConfig) {
             .route(
                 "/external_db/open_library",
                 web::get().to(get_open_library_data),
-            ),
+            )
+            .route(
+                "/external_db/tmdb/movie",
+                web::get().to(get_tmdb_movie_data),
+            )
+            .route("/external_db/tmdb/tv", web::get().to(get_tmdb_tv_data)),
     );
 }


### PR DESCRIPTION
A first pass has been done to map the TMDB API-returned data fields and the title group data, it's likely it will need to be revisited with frontend integration.

Note that this API now requires the registration at TMDB and retreiving a bearer token from their development page.