### PR TITLE
user: allocate passkey on user registration

### DIFF
--- a/migrations/20250312215600_initdb.sql
+++ b/migrations/20250312215600_initdb.sql
@@ -31,7 +31,11 @@ CREATE TABLE users (
     invited BIGINT NOT NULL DEFAULT 0,
     invitations SMALLINT NOT NULL DEFAULT 0,
     bonus_points BIGINT NOT NULL DEFAULT 0,
-    settings JSONB NOT NULL
+    settings JSONB NOT NULL DEFAULT '{}',
+    passkey_upper BIGINT NOT NULL,
+    passkey_lower BIGINT NOT NULL,
+
+    UNIQUE(passkey_upper, passkey_lower)
 );
 CREATE TABLE invitations (
     id BIGSERIAL PRIMARY KEY,

--- a/migrations/fixtures/fixtures.sql
+++ b/migrations/fixtures/fixtures.sql
@@ -22,11 +22,11 @@ SET row_security = off;
 -- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: arcadia
 --
 
-COPY public.users (id, username, avatar, email, password_hash, registered_from_ip, created_at, description, uploaded, downloaded, ratio, required_ratio, last_seen, class, forum_posts, forum_threads, group_comments, torrent_comments, request_comments, artist_comments, seeding, leeching, snatched, seeding_size, requests_filled, collages_started, requests_voted, average_seeding_time, invited, invitations, bonus_points, settings) FROM stdin;
-2	waterbottle	https://i.pinimg.com/736x/a6/27/12/a6271204df8d387c3e614986c106f549.jpg	user2@example.com	hashedpassword2	192.168.1.2	2025-03-30 16:24:57.388152		0	1	0	0	2025-03-30 16:24:57.388152	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	{}
-3	coolguy	https://i.pinimg.com/474x/c1/5a/6c/c15a6c91515e22f6ea8b766f89c12f0c.jpg	user3@example.com	hashedpassword3	192.168.1.3	2025-03-30 16:24:57.388152		0	1	0	0	2025-03-30 16:24:57.388152	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	{}
-1	picolo	https://img.freepik.com/premium-vector/random-people-line-art-vector_567805-63.jpg	user1@example.com	$argon2id$v=19$m=19456,t=2,p=1$s4XJtCUk9IrGgNsTfP6Ofw$ktoGbBEoFaVgdiTn19Gh9h45LjFiv7AUEL5KHhzm4d0	192.168.1.1	2025-03-30 16:24:57.388152		10000	1	0	0	2025-04-02 10:40:15.558334	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	1000000000	{}
-4	test	\N	test@test.tsttt	$argon2id$v=19$m=19456,t=2,p=1$yaA+WqA4OfSyAqR3iXhDng$/Ngv7VeJvVNHli9rBgQG0d/O2W+qoI2yHhQxZSxxW2M	127.0.0.1	2025-04-10 19:15:51.036818		0	1	0	0	2025-04-10 19:15:51.036818	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	{}
+COPY public.users (id, username, avatar, email, password_hash, registered_from_ip, created_at, description, uploaded, downloaded, ratio, required_ratio, last_seen, class, forum_posts, forum_threads, group_comments, torrent_comments, request_comments, artist_comments, seeding, leeching, snatched, seeding_size, requests_filled, collages_started, requests_voted, average_seeding_time, invited, invitations, bonus_points, settings, passkey_upper, passkey_lower) FROM stdin;
+2	waterbottle	https://i.pinimg.com/736x/a6/27/12/a6271204df8d387c3e614986c106f549.jpg	user2@example.com	hashedpassword2	192.168.1.2	2025-03-30 16:24:57.388152		0	1	0	0	2025-03-30 16:24:57.388152	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	{}	5493004881313328037	2566432999990446913
+3	coolguy	https://i.pinimg.com/474x/c1/5a/6c/c15a6c91515e22f6ea8b766f89c12f0c.jpg	user3@example.com	hashedpassword3	192.168.1.3	2025-03-30 16:24:57.388152		0	1	0	0	2025-03-30 16:24:57.388152	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	{}	2274483400846363122	1270934296711348124
+1	picolo	https://img.freepik.com/premium-vector/random-people-line-art-vector_567805-63.jpg	user1@example.com	$argon2id$v=19$m=19456,t=2,p=1$s4XJtCUk9IrGgNsTfP6Ofw$ktoGbBEoFaVgdiTn19Gh9h45LjFiv7AUEL5KHhzm4d0	192.168.1.1	2025-03-30 16:24:57.388152		10000	1	0	0	2025-04-02 10:40:15.558334	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	1000000000	{}	-197409747985172542	1837889239438807682
+4	test	\N	test@test.tsttt	$argon2id$v=19$m=19456,t=2,p=1$yaA+WqA4OfSyAqR3iXhDng$/Ngv7VeJvVNHli9rBgQG0d/O2W+qoI2yHhQxZSxxW2M	127.0.0.1	2025-04-10 19:15:51.036818		0	1	0	0	2025-04-10 19:15:51.036818	newbie	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	{}	-7167291202215854785	1526268353104531819
 \.
 
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -65,6 +65,8 @@ pub struct User {
     pub invitations: i16,
     pub bonus_points: i64,
     pub settings: serde_json::Value,
+    pub passkey_upper: i64,
+    pub passkey_lower: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
A `passkey` will be encoded in the users' snatched torrent file, and is used to uniquely identify them to the tracker.  Make use of a 128-bit passkey, should give plenty of entropy to avoid bruteforce guessing attacks.

Postgres does not have a native u128 type, so instead marshal the generated 128-bit type into two 64-bit components, each inserted as an upper and lower pair.

While we're here, default the `settings` column to an empty dict to facilitate easier user insertions.