### PR TITLE
tests: fix with recent updates

### DIFF
--- a/tests/fixtures/with_test_user.sql
+++ b/tests/fixtures/with_test_user.sql
@@ -1,4 +1,4 @@
 INSERT INTO
-    users (username, email, password_hash, registered_from_ip)
+    users (username, email, password_hash, registered_from_ip, passkey_upper, passkey_lower)
 VALUES
-    ('test_user', 'test_email@testdomain.com', '$argon2id$v=19$m=19456,t=2,p=1$WM6V9pJ2ya7+N+NNIUtolg$n128u9idizCHLwZ9xhKaxOttLaAVZZgvfRZlRAnfyKk', '10.10.4.88')
+    ('test_user', 'test_email@testdomain.com', '$argon2id$v=19$m=19456,t=2,p=1$WM6V9pJ2ya7+N+NNIUtolg$n128u9idizCHLwZ9xhKaxOttLaAVZZgvfRZlRAnfyKk', '10.10.4.88', '-3313668119574211836', '5624203854722381879')

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -6,17 +6,26 @@ use actix_web::{
     test, web,
 };
 use arcadia_index::{Arcadia, OpenSignups};
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
+use std::path::PathBuf;
 
 async fn create_test_app(
     pool: PgPool,
     open_signups: OpenSignups,
 ) -> impl Service<Request, Response = ServiceResponse, Error = Error> {
+    let arc = Arcadia {
+        pool,
+        open_signups,
+        dottorrent_files_path: PathBuf::new(),
+        frontend_url: Url::parse("http://testurl").unwrap(),
+    };
+
     // TODO: CORS?
     test::init_service(
         App::new()
-            .app_data(web::Data::new(Arcadia { pool, open_signups }))
+            .app_data(web::Data::new(arc))
             .configure(arcadia_index::routes::init),
     )
     .await


### PR DESCRIPTION
Tests were broken with the addition of the passkey and additional Arcadia parameters (torrent dir and frontend url).  Fix everything up and get them running again (and passing!).